### PR TITLE
feat: add ref support to editors

### DIFF
--- a/imperative.html
+++ b/imperative.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Editor</title>
+    <style>
+      html,
+      body,
+      #root {
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="button"></div>
+    <div id="root"></div>
+    <script type="module" src="/imperative.jsx"></script>
+  </body>
+</html>

--- a/imperative.jsx
+++ b/imperative.jsx
@@ -1,0 +1,13 @@
+import { render, useRef, createElement } from 'axii'
+import { render as renderEditor, emptyContent, setup } from "./packages/sheetEditor/SheetEditor";
+
+render(createElement(function() {
+    const editor = useRef()
+
+    renderEditor({...setup(emptyContent), ref: editor}, document.getElementById('root'))
+    
+    return <button onClick={() => {
+        console.log(editor.current.getData())
+    }}>Save</button>
+    
+}), document.getElementById('root'))

--- a/packages/codeEditor/CodeEditor.js
+++ b/packages/codeEditor/CodeEditor.js
@@ -1,3 +1,4 @@
+import {useImperativeHandle} from 'axii'
 import Shortcut from "@codexteam/shortcuts";
 import CodeMirror from 'codemirror'
 import styleInject from 'style-inject'
@@ -28,7 +29,7 @@ const extensionToLanguage = {
 
 export const readAsText = true
 
-export async function render({ content = '', onSave, onChange, title = '' }, root) {
+export async function render({ content = '', onSave, onChange, title = '', ref }, root) {
 
 
   const language = Object.entries(extensionToLanguage).find(([ext, value]) => {
@@ -41,6 +42,11 @@ export async function render({ content = '', onSave, onChange, title = '' }, roo
       theme: "dracula",
     });
 
+  if(ref) {
+    useImperativeHandle(ref, () => ({
+      getData: () => editor.getValue()
+    }))
+  }
 
   new Shortcut({
     name : 'CMD+S',

--- a/packages/docEditor/DocEditor.jsx
+++ b/packages/docEditor/DocEditor.jsx
@@ -1,5 +1,5 @@
 /**@jsx createElement */
-import {createElement, useRef, render as renderComponent} from 'axii'
+import {createElement, useRef, render as renderComponent, useImperativeHandle} from 'axii'
 import Editorjs from 'axii-components/dist/editorjs/index.js'
 import Shortcut from '@codexteam/shortcuts'
 
@@ -15,7 +15,7 @@ export function setup(content) {
 
 export const readAsText = true
 
-export function render({ data, onSave, onChange }, root) {
+export function render({ data, onSave, onChange, ref }, root) {
   const editor = useRef()
   const tools = {
     image: {
@@ -27,6 +27,12 @@ export function render({ data, onSave, onChange }, root) {
     table: {
       class: Editorjs.TablePlugin
     }
+  }
+  
+  if(ref) {
+    useImperativeHandle(ref, () => ({
+      getData: async () => JSON.stringify(await editor.current.save())
+    }))
   }
 
   new Shortcut({

--- a/packages/erEditor/EREditor.jsx
+++ b/packages/erEditor/EREditor.jsx
@@ -1,6 +1,6 @@
 /**@jsx createElement */
 import path from "path-browserify";
-import {createElement, render as renderComponent} from 'axii'
+import {createElement, render as renderComponent, useRef, useImperativeHandle} from 'axii'
 import { EREditor } from 'axii-x6'
 import Shortcut from '@codexteam/shortcuts'
 //export const test = /\.storage\.json$/
@@ -32,8 +32,14 @@ export async function setup(content, filePath, {api, dirs}) {
   }
 }
 
-export function render({ data, customFields, onSave }, root) {
+export function render({ data, customFields, onSave, ref }, root) {
+  const editor = useRef()
   const onDataSave = (d) => onSave(JSON.stringify(d))
-  renderComponent(<EREditor data={data} customFields={customFields} onSave={onDataSave}/>, root)
+  if(ref) {
+    useImperativeHandle(ref, () => ({
+      getData: () => JSON.stringify(editor.current.getData())
+    }))
+  }
+  renderComponent(<EREditor data={data} customFields={customFields} ref={editor} onSave={onDataSave}/>, root)
 }
 

--- a/packages/imageEditor/ImageEditor.jsx
+++ b/packages/imageEditor/ImageEditor.jsx
@@ -1,5 +1,5 @@
 /**@jsx createElement */
-import {createElement} from 'axii'
+import {createElement, useImperativeHandle} from 'axii'
 import ImageEditor from 'tui-image-editor'
 
 import Shortcut from "@codexteam/shortcuts";
@@ -41,7 +41,7 @@ function dataURLtoFile(dataurl, filename) {
   return new File([dataURLtoBinary(dataurl)], filename, {type:mime});
 }
 
-export async function render({ title, content, onSave }, root) {
+export async function render({ title, content, onSave, ref }, root) {
   const ext = title.split('.').pop()
   const mimeType = mimeTypeMap[ext]
 
@@ -51,6 +51,13 @@ export async function render({ title, content, onSave }, root) {
       menu: ['crop', 'flip', 'rotate', 'draw', 'shape', 'icon', 'text', 'mask', 'filter']
     }
   })
+
+  if(ref) {
+    useImperativeHandle(ref, () => ({
+      // NOTE: 此处不删减encoding前缀，需要外部自行处理
+      getData: () => editor.toDataURL({format: ext})
+    }))
+  }
 
   new Shortcut({
     name : 'CMD+S',

--- a/packages/sheetEditor/SheetEditor.jsx
+++ b/packages/sheetEditor/SheetEditor.jsx
@@ -1,4 +1,5 @@
 import Shortcut from "@codexteam/shortcuts";
+import {useImperativeHandle} from 'axii'
 
 export const extension = '.sheet.json'
 
@@ -89,7 +90,7 @@ const defaultData = [
 
 export const emptyContent = JSON.stringify(defaultData)
 
-export function render({ data, onSave, title }, root) {
+export function render({ data, onSave, title, ref }, root) {
   let sheetEditor
   Promise.all([
     appendStylesheet('https://cdn.jsdelivr.net/npm/luckysheet/dist/plugins/css/pluginsCss.css'),
@@ -111,6 +112,12 @@ export function render({ data, onSave, title }, root) {
   }).catch(e => {
     console.error(e)
   })
+  
+  if(ref) {
+    useImperativeHandle(ref, () => ({
+      getData: () => JSON.stringify(luckysheet.getAllSheets())
+    }))
+  }
 
   new Shortcut({
     name : 'CMD+S',

--- a/packages/tableEditor/TableEditor.jsx
+++ b/packages/tableEditor/TableEditor.jsx
@@ -1,5 +1,5 @@
 /**@jsx createElement */
-import {createElement, useRef, render as renderComponent} from 'axii'
+import {createElement, useRef, render as renderComponent, useImperativeHandle} from 'axii'
 import ToastGrid from 'axii-components/dist/toastGrid/index.js'
 
 const extension = '.table.json'
@@ -15,7 +15,7 @@ export async function setup(content) {
   }
 }
 
-export function render({ data: tables }, root) {
+export function render({ data: tables, ref }, root) {
   const editor = useRef()
   const save = () => {
     console.log('不能 save，这是个生成的文件')
@@ -39,6 +39,12 @@ export function render({ data: tables }, root) {
     }, {})
   }))
 
+  if(ref) {
+    useImperativeHandle(ref, () => ({
+      // NOTE: 不支持保存
+      getData: () => {}
+    }))
+  }
 
   renderComponent (
     <div>


### PR DESCRIPTION
A `MutableRefObject` can be passed to each editor, which allows to get an imperative handler to call `getData` on editor instances.

*NOTE: some `getData` might be async*

```javascript
// to use ref, a wrapper render function must be created
render(createElement(function() {
    const editor = useRef()
    renderEditor({ ref: editor }, document.getElementById('root'))
    // get editor data
    // editor.current.getData()
    return null
}), document.getElementById('root'))
```